### PR TITLE
provide locals record to partial

### DIFF
--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,2 +1,2 @@
 <h1>Create a new <%= model_label(params[:type]) %> record</h1>
-<%= render :partial=>'form' %>
+<%= render :partial=>'form', locals: {record: @record} %>


### PR DESCRIPTION
Fixes what I believe is a bug where the 'form' partial does not have a reference to the 'record' object when rendered as part of the 'new' view.  This replicates the code used when rendering the 'form' partial as part of the 'edit' view.
