### PR TITLE
Exclude spec/dummy from gem test files.

### DIFF
--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
-
+  s.test_files.reject! { |fn| fn.start_with?("spec/dummy/") }
+  
   s.add_dependency "rails", ">= 3.2.13", "< 5.0"
   s.add_dependency "bootstrap_forms"
   s.add_dependency "active-fedora", ">= 6.3.0"  


### PR DESCRIPTION
The dummy application files generated by testing should not be included in the gem.
