### PR TITLE
Added #redirect_after_create and #redirect_after_update methods

### DIFF
--- a/app/controllers/concerns/records_controller_behavior.rb
+++ b/app/controllers/concerns/records_controller_behavior.rb
@@ -27,8 +27,8 @@ module RecordsControllerBehavior
 
     respond_to do |format|
       if @record.save
-        format.html { redirect_to main_app.catalog_path(@record), notice: 'Object was successfully created.' }
-        # ActiveFedora::Base#to_json causes a circular reference.  Do somethign easy
+        format.html { redirect_to redirect_after_create, notice: 'Object was successfully created.' }
+        # ActiveFedora::Base#to_json causes a circular reference.  Do something easy
         data = @record.terms_for_editing.inject({}) { |h,term|  h[term] = @record[term]; h } 
         format.json { render json: data, status: :created, location: hydra_editor.record_path(@record) }
       else
@@ -45,7 +45,7 @@ module RecordsControllerBehavior
     set_attributes
     respond_to do |format|
       if @record.save
-        format.html { redirect_to main_app.catalog_path(@record), notice: 'Object was successfully updated.' }
+        format.html { redirect_to redirect_after_update, notice: 'Object was successfully updated.' }
         format.json { head :no_content }
       else
         format.html { render action: "edit" }
@@ -61,6 +61,14 @@ module RecordsControllerBehavior
     @record.attributes = params[ActiveModel::Naming.singular(@record)]
   end
 
+  # Override to redirect to an alternate location after create
+  def redirect_after_create
+    main_app.catalog_path @record
+  end
+
+  def redirect_after_update
+    main_app.catalog_path @record
+  end
 
   def has_valid_type?
     HydraEditor.models.include? params[:type]

--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -9,12 +9,12 @@ describe RecordsController do
     end
     describe "who goes to the new page" do
       it "should be successful" do
-        get :new
+        get :new, use_route: 'hydra_editor'
         response.should be_successful
         response.should render_template(:choose_type)
       end
       it "should be successful" do
-        get :new, :type=>'Audio'
+        get :new, :type=>'Audio', :use_route=>'hydra_editor'
         response.should be_successful
         response.should render_template(:new)
       end
@@ -28,12 +28,12 @@ describe RecordsController do
         stub_audio.should_receive(:save).and_return(true)
       end
       it "should be successful" do
-        post :create, :type=>'Audio', :audio=>{:title=>"My title"}
+        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :use_route=>'hydra_editor'
         response.should redirect_to("/catalog/#{assigns[:record].id}") 
         assigns[:record].title.should == ['My title']
       end
       it "should be successful with json" do
-        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :format=>:json
+        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :format=>:json, :use_route=>'hydra_editor'
         response.status.should == 201 
       end
       describe "when set_attributes is overloaded" do
@@ -44,9 +44,16 @@ describe RecordsController do
           end
         end
         it "should run set_attributes" do
-          post :create, :type=>'Audio', :audio=>{:title=>"My title"}
+          post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :use_route=>'hydra_editor'
           response.should redirect_to("/catalog/#{assigns[:record].id}") 
           assigns[:record].pid.should == 'tufts:0001'
+        end
+      end
+      describe "when redirect_after_create is overridden" do
+        it "should redirect to the alternate location" do
+          controller.stub(:redirect_after_create).and_return(root_url)
+          post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :use_route=>'hydra_editor'
+          response.should redirect_to(root_url) 
         end
       end
     end
@@ -58,7 +65,7 @@ describe RecordsController do
         controller.should_receive(:authorize!).with(:edit, @audio)
       end
       it "should be successful" do
-        get :edit, :id=>@audio.pid
+        get :edit, :id=>@audio.pid, :use_route=>'hydra_editor'
         response.should be_successful
         assigns[:record].title.should == ['My title2']
       end
@@ -73,18 +80,23 @@ describe RecordsController do
         controller.should_receive(:authorize!).with(:update, @audio)
       end
       it "should be successful" do
-        put :update, :id=>@audio, :audio=>{:title=>"My title 3"}
+        put :update, :id=>@audio, :audio=>{:title=>"My title 3"}, :use_route=>'hydra_editor'
         response.should redirect_to("/catalog/#{assigns[:record].id}") 
         assigns[:record].title.should == ['My title 3']
       end
       it "should be successful with json" do
-        put :update, :id=>@audio, :audio=>{:title=>"My title"}, :format=>:json
+        put :update, :id=>@audio.pid, :audio=>{:title=>"My title"}, :format=>:json, :use_route=>'hydra_editor'
         response.status.should == 204 
       end
-
+      describe "when redirect_after_update is overridden" do
+        it "should redirect to the alternate location" do
+          controller.stub(:redirect_after_update).and_return(root_url)
+          put :update, :id=>@audio, :audio=>{:title=>"My title 3"}, :use_route=>'hydra_editor'
+          response.should redirect_to(root_url) 
+        end
+      end
     end
   end
-
 
   describe "a user without create ability" do
     before do
@@ -94,8 +106,9 @@ describe RecordsController do
     end
     describe "who goes to the new page" do
       it "should not be allowed" do
-        lambda { get :new }.should raise_error CanCan::AccessDenied
+        lambda { get :new, :use_route=>'hydra_editor' }.should raise_error CanCan::AccessDenied
       end
     end
   end
+
 end


### PR DESCRIPTION
... to permit apps to easily override the default engine behavior (Fixes #8).

Incidentally fixed routing errors in spec tests.
