### PR TITLE
Moves load and authz of record into before_filter for :edit and :update.

### DIFF
--- a/app/controllers/concerns/records_controller_behavior.rb
+++ b/app/controllers/concerns/records_controller_behavior.rb
@@ -1,4 +1,10 @@
 module RecordsControllerBehavior
+  extend ActiveSupport::Concern
+
+  included do
+    before_filter :load_and_authorize_record, only: [:edit, :update]
+  end
+
   def new
     authorize! :create, ActiveFedora::Base
     unless has_valid_type?
@@ -11,8 +17,6 @@ module RecordsControllerBehavior
   end
 
   def edit
-    @record = ActiveFedora::Base.find(params[:id], cast: true)
-    authorize! :edit, @record
     initialize_fields
   end
 
@@ -40,8 +44,6 @@ module RecordsControllerBehavior
   end
 
   def update
-    @record = ActiveFedora::Base.find(params[:id], cast: true)
-    authorize! :update, @record
     set_attributes
     respond_to do |format|
       if @record.save
@@ -55,6 +57,11 @@ module RecordsControllerBehavior
   end
 
   protected
+
+  def load_and_authorize_record
+    @record = ActiveFedora::Base.find(params[:id], cast: true)
+    authorize! self.action_name.to_sym, @record
+  end
 
   # Override this method if you want to set different metadata on the object
   def set_attributes

--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -9,12 +9,12 @@ describe RecordsController do
     end
     describe "who goes to the new page" do
       it "should be successful" do
-        get :new
+        get :new, use_route: 'hydra_editor'
         response.should be_successful
         response.should render_template(:choose_type)
       end
       it "should be successful" do
-        get :new, :type=>'Audio'
+        get :new, :type=>'Audio', :use_route=>'hydra_editor'
         response.should be_successful
         response.should render_template(:new)
       end
@@ -28,12 +28,12 @@ describe RecordsController do
         stub_audio.should_receive(:save).and_return(true)
       end
       it "should be successful" do
-        post :create, :type=>'Audio', :audio=>{:title=>"My title"}
+        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :use_route=>'hydra_editor'
         response.should redirect_to("/catalog/#{assigns[:record].id}") 
         assigns[:record].title.should == ['My title']
       end
       it "should be successful with json" do
-        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :format=>:json
+        post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :format=>:json, :use_route=>'hydra_editor'
         response.status.should == 201 
       end
       describe "when set_attributes is overloaded" do
@@ -44,7 +44,7 @@ describe RecordsController do
           end
         end
         it "should run set_attributes" do
-          post :create, :type=>'Audio', :audio=>{:title=>"My title"}
+          post :create, :type=>'Audio', :audio=>{:title=>"My title"}, :use_route=>'hydra_editor'
           response.should redirect_to("/catalog/#{assigns[:record].id}") 
           assigns[:record].pid.should == 'tufts:0001'
         end
@@ -58,7 +58,7 @@ describe RecordsController do
         controller.should_receive(:authorize!).with(:edit, @audio)
       end
       it "should be successful" do
-        get :edit, :id=>@audio.pid
+        get :edit, :id=>@audio.pid, :use_route=>'hydra_editor'
         response.should be_successful
         assigns[:record].title.should == ['My title2']
       end
@@ -73,18 +73,16 @@ describe RecordsController do
         controller.should_receive(:authorize!).with(:update, @audio)
       end
       it "should be successful" do
-        put :update, :id=>@audio, :audio=>{:title=>"My title 3"}
+        put :update, :id=>@audio, :audio=>{:title=>"My title 3"}, :use_route=>'hydra_editor'
         response.should redirect_to("/catalog/#{assigns[:record].id}") 
         assigns[:record].title.should == ['My title 3']
       end
       it "should be successful with json" do
-        put :update, :id=>@audio, :audio=>{:title=>"My title"}, :format=>:json
+        put :update, :id=>@audio.pid, :audio=>{:title=>"My title"}, :format=>:json, :use_route=>'hydra_editor'
         response.status.should == 204 
       end
-
     end
   end
-
 
   describe "a user without create ability" do
     before do
@@ -94,8 +92,9 @@ describe RecordsController do
     end
     describe "who goes to the new page" do
       it "should not be allowed" do
-        lambda { get :new }.should raise_error CanCan::AccessDenied
+        lambda { get :new, :use_route=>'hydra_editor' }.should raise_error CanCan::AccessDenied
       end
     end
   end
+
 end


### PR DESCRIPTION
This permits mounting app to add filters that depend on record being loaded and authz'd.

Incidentally repeats fixes of routing errors also corrected in https://github.com/projecthydra/hydra-editor/pull/9.
