### PR TITLE
Make RecordsControllerBehavior more reusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ And to config/routes.rb add:
   mount HydraEditor::Engine => '/'
 ```
 
+(Note: You do not have to mount the engine if you do not intend to use the engine's default routes.)
+
 In your initialization set ```HydraEditor.models```
 
 ```ruby
@@ -24,14 +26,15 @@ You can customize the names of your fields/models by adding to your translation 
 ```yaml
 # config/locales/en.yml
 en:
-  hydra:
-    field_label:
-      source2: "Alternate Source"
-      dateCreated: "Date Created"
-      dateAvailable: "Date Available"
-    model_label:
-      PdfModel: "PDF"
-      RecordedAudio: "audio"
+  hydra_editor:
+    form:
+      field_label:
+        source2: "Alternate Source"
+        dateCreated: "Date Created"
+        dateAvailable: "Date Available"
+      model_label:
+        PdfModel: "PDF"
+        RecordedAudio: "audio"
 
 ```
 
@@ -46,6 +49,21 @@ Add the javascript by adding this line to your app/assets/javascript/application
 ```
 
 Add the stylesheets by adding this line to your app/assets/stylesheets/application.css:
+
 ```css
  *= require hydra-editor/hydra-editor
 ```
+
+## Other customizations
+
+By default hydra-editor provides a RecordsController with :new, :create, :edit, and :update actions implemented in the included RecordsControllerBehavior module, and a RecordsHelper module with methods implemented in RecordsHelperBehavior.  If you are mounting the engine and using its routes, you can override the controller behaviors by creating your own RecordsController:
+
+```ruby
+class RecordsController < ApplicationController
+  include RecordsControllerBehavior
+
+  # You custom code
+end
+```
+
+If you are not mounting the engine or using its default routes, you can include RecordsControllerBehavior in your own controller and add the appropriate routes to your app's config/routes.rb.

--- a/app/helpers/concerns/records_helper_behavior.rb
+++ b/app/helpers/concerns/records_helper_behavior.rb
@@ -1,15 +1,15 @@
 module RecordsHelperBehavior
   
   def metadata_help(key)
-    I18n.t("hydra.metadata_help.#{key}", default: key.to_s.humanize)
+    I18n.t("hydra_editor.form.metadata_help.#{key}", default: key.to_s.humanize)
   end
 
   def field_label(key)
-    I18n.t("hydra.field_label.#{key}", default: key.to_s.humanize)
+    I18n.t("hydra_editor.form.field_label.#{key}", default: key.to_s.humanize)
   end
 
   def model_label(key)
-    I18n.t("hydra.model_label.#{key}", default: key.to_s.humanize)
+    I18n.t("hydra_editor.form.model_label.#{key}", default: key.to_s.humanize)
   end
 
   def object_type_options
@@ -30,6 +30,23 @@ module RecordsHelperBehavior
 
   def subtract_field (key)
     more_or_less_button(key, 'remover', '-')
+  end
+
+  def record_form_action_url(record)
+    router = respond_to?(:hydra_editor) ? hydra_editor : self
+    record.new_record? ? router.records_path : router.record_path(record)
+  end
+
+  def new_record_title
+    I18n.t('hydra_editor.new.title') % model_label(params[:type])
+  end
+
+  def edit_record_title
+    I18n.t('hydra_editor.edit.title') % render_record_title
+  end
+
+  def render_record_title
+    Array(@record.title).first
   end
 
  private 

--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -1,11 +1,14 @@
-<%= bootstrap_form_for record, :url=>record.new_record? ? hydra_editor.records_path : hydra_editor.record_path(record), html: {:class => 'form-inline editor'} do |f| %>
+<%= bootstrap_form_for record, url: record_form_action_url(record), html: {:class => 'form-inline editor'} do |f| %>
   <div id="descriptions_display">
-    <h2 class="non lower">Descriptions <small class="pull-right"><span class="error">*</span> indicates required fields</small> </h2>
+    <h2 class="non lower">
+	  <%= t('hydra_editor.form.title') %>
+	  <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small> 
+	</h2>
     <div class="well">
       <% f.object.terms_for_editing.each do |term| %>
-        <%= render :partial => "records/edit_field", :locals => {:f =>f, :render_req => true, :key => term } %>
+        <%= render :partial => "records/edit_field", :locals => {:f => f, :render_req => true, :key => term } %>
       <% end %>
-    </div><!-- /well -->
+    </div> <!-- /well -->
   </div>
   <%= hidden_field_tag :type, params[:type] %>
   <%= f.actions do %>

--- a/app/views/records/choose_type.html.erb
+++ b/app/views/records/choose_type.html.erb
@@ -1,8 +1,7 @@
-<h1>Create a new record</h1>
-
-<%= bootstrap_form_tag hydra_editor.new_record_path, :method=>:get do |f| %>
+<h1><%= t('hydra_editor.choose_type.title') %></h1>
+<%= bootstrap_form_tag new_hydra_editor_record_path, :method => :get do |f| %>
   <%= bootstrap_select_tag :type, options_for_select(object_type_options) %>
   <%= bootstrap_actions do %>
-    <%= bootstrap_submit_tag 'Next'%>
+    <%= bootstrap_submit_tag 'Next' %>
   <% end %>
 <% end %>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>Edit <%= Array(@record.title).first %></h1>
-<%= render :partial=>'form', locals: {record: @record}  %>
+<h1><%= edit_record_title %></h1>
+<%= render :partial=>'records/form', locals: {record: @record}  %>
 

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,2 +1,2 @@
-<h1>Create a new <%= model_label(params[:type]) %> record</h1>
-<%= render :partial=>'form', locals: {record: @record} %>
+<h1><%= new_record_title %></h1>
+<%= render :partial=>'records/form', locals: {record: @record} %>

--- a/config/locales/hydra_editor.yml
+++ b/config/locales/hydra_editor.yml
@@ -1,0 +1,11 @@
+en:
+  hydra_editor:
+    choose_type:
+      title: 'Create a New Record'
+    edit:
+      title: 'Edit %s'
+    form:
+      title: 'Descriptions'
+      required_fields: 'indicates required fields'
+    new:
+      title: 'Create a New %s Record'

--- a/spec/helpers/records_helper_spec.rb
+++ b/spec/helpers/records_helper_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe RecordsHelper do
   it "should have object_type_options" do
     HydraEditor.models = ['Audio', 'Pdf']
-    I18n.stub(:t).with("hydra.model_label.Audio", default: 'Audio').and_return('Audio')
-    I18n.stub(:t).with("hydra.model_label.Pdf", default: 'Pdf').and_return('PDF')
+    I18n.stub(:t).with("hydra_editor.form.model_label.Audio", default: 'Audio').and_return('Audio')
+    I18n.stub(:t).with("hydra_editor.form.model_label.Pdf", default: 'Pdf').and_return('PDF')
     helper.object_type_options.should == {'Audio' => 'Audio', 'PDF' => 'Pdf'}
   end
 


### PR DESCRIPTION
The primary purpose of this commit is to make RecordsControllerBehavior more reusable without requiring RecordsController or mounting HydraEditor::Engine. A secondary purpose is to improve the flexibility of the templates and partials by the addition of helpers and I18n. Incidental to making the latter modifications, the existing I18n keys have been moved from `hydra` to `hydra_editor.form` in order to avoid clashes with other existing or future Hydra components.
