### PR TITLE
change records routes to allow dashes in pid, and add spec

### DIFF
--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -104,18 +104,6 @@ describe RecordsController do
       end
     end
 
-    describe "when generating an edit path" do
-      before do
-        @stub_audio = Audio.new(pid: 'test:7.a-b')
-        @stub_audio.stub(:persisted?).and_return(true)
-        @stub_audio.stub(:save).and_return(true)
-      end
-
-      it 'should generate a valid edit path for pid' do
-        edit_record_path(@stub_audio).should eq '/records/test:7.a-b/edit'
-      end
-    end
-
     describe "updating a record" do
       before do
         @audio = Audio.new(title: 'My title2', pid: 'test:7')

--- a/spec/routing/records_routing_spec.rb
+++ b/spec/routing/records_routing_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe "routes to the records controller" do
+
+  routes { HydraEditor::Engine.routes }
+
+  before do
+    @audio = Audio.new(pid: 'test:7.a-b')
+    @audio.stub(:persisted?).and_return(true)
+    @audio.stub(:save).and_return(true)
+  end
+
+  it "should handle pids with hyphens" do
+    expect(:get => edit_record_path(@audio)).
+        to route_to(:controller => "records", :action => "edit", :id => "test:7.a-b")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
-  config.include HydraEditor::Engine.routes.url_helpers
   # see https://github.com/rails/journey/issues/39
   config.before(:each, :type=>"controller") { @routes = HydraEditor::Engine.routes }
 


### PR DESCRIPTION
I modified the routes file for hydra-editor to allow dashes in the pid, and added an accompanying spec test, that replicates the problem we saw where 'edit_record_path' was raising an exception for pids with dashes.
