### PR TITLE
Factor out existing <h2> content of records/form partial to records/form_header partial.

### DIFF
--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -1,9 +1,6 @@
 <%= bootstrap_form_for resource, url: record_form_action_url(resource), html: {:class => 'form-inline editor'} do |f| %>
   <div id="descriptions_display">
-    <h2 class="non lower">
-	  <%= t('hydra_editor.form.title') %>
-	  <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small> 
-	</h2>
+	<%= render 'records/form_header' %>
     <div class="well">
       <% f.object.terms_for_editing.each do |term| %>
         <%= render :partial => "records/edit_field", :locals => {:f => f, :render_req => true, :key => term } %>

--- a/app/views/records/_form_header.html.erb
+++ b/app/views/records/_form_header.html.erb
@@ -1,0 +1,4 @@
+    <h2 class="non lower">
+	  <%= t('hydra_editor.form.title') %>
+	  <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small> 
+	</h2>


### PR DESCRIPTION
To allow for customization without overriding records/form completely.
