### PR TITLE
Restrict `simple_form` to `<= 3.5.0`

### DIFF
--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 4.2.0", "< 6"
   s.add_dependency "active-fedora", ">= 9.0.0"
   s.add_dependency "cancancan", "~> 1.8"
-  s.add_dependency "simple_form", '~> 3.2'
+  s.add_dependency "simple_form", '~> 3.2', '<= 3.5.0'
   s.add_dependency 'sprockets-es6'
   s.add_dependency "almond-rails", '~> 0.1'
 


### PR DESCRIPTION
Beginning with `v3.5.1`, Simple Form now requires models passed to it to conform
to the `ActiveModel` interface; particularly, they must implement
`#to_model`. We will restrict to `<= 3.5.0` to prevent unexpected breakage for
downstream apps.

Support for `v3.5.1` and up should be readded (this may just require
testing/documentation fixes) and a major version released to get us back to
tracking current `simple_form` development.

See also: https://github.com/samvera/hyrax/pull/2758 and
https://github.com/plataformatec/simple_form/issues/1549.