### PR TITLE
Remove `#to_model` delegation from `Hydra::Presenter`

### DIFF
--- a/app/presenters/hydra/presenter.rb
+++ b/app/presenters/hydra/presenter.rb
@@ -14,8 +14,7 @@ module Hydra
       @model = object
     end
 
-    delegate :to_key, :to_param, :to_model, :persisted?, :new_record?,
-             :[], :model_name, to: :model
+    delegate :to_key, :to_param, :persisted?, :new_record?, :[], :model_name, to: :model
 
     module ClassMethods
       def model_name
@@ -33,8 +32,8 @@ module Hydra
     included do
       class_attribute :_terms, instance_accessor: false
 
-      # You may want to set your own field_metadata_service that can 
-      # answer the questions about a fields cardinality regardless of the 
+      # You may want to set your own field_metadata_service that can
+      # answer the questions about a fields cardinality regardless of the
       # cardinality of the model
       class_attribute :field_metadata_service
       # This default service just give us the cardiality defined in the model.

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 4.2.0", "< 6"
   s.add_dependency "active-fedora", ">= 9.0.0"
   s.add_dependency "cancancan", "~> 1.8"
-  s.add_dependency "simple_form", '~> 3.2', '<= 3.5.0'
+  s.add_dependency "simple_form", '~> 3.2'
   s.add_dependency 'sprockets-es6'
   s.add_dependency "almond-rails", '~> 0.1'
 

--- a/lib/hydra_editor/version.rb
+++ b/lib/hydra_editor/version.rb
@@ -1,3 +1,3 @@
 module HydraEditor
-  VERSION = '3.4.0.beta'.freeze
+  VERSION = '4.0.0.rc1'.freeze
 end


### PR DESCRIPTION
Beginning in `v3.5.1`, `SimpleForm::FormBuilder` calls `#to_model` (via
ActionView's `#convert_to_model`) in its initializer. This prevents
`Hydra::Presenter` inheritors from being used correctly when sent to the
form. Removing the method allows the Form/Presenter object to be used as
expected.

Client code can still access the model by calling the `#model` accessor.

Fixes #139.

This would necessitate a 4.0.0 release.