### PR TITLE
Updates HydraEditor::Form.model_attributes.

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -56,11 +56,17 @@ module HydraEditor
       #   ImageForm.model_attributes(params[:image])
       #   # => { title: 'My new image' }
       def model_attributes(form_params)
-        clean_params = sanitize_params(form_params)
-        terms.each do |key|
-          clean_params[key].delete('') if clean_params[key]
+        sanitize_params(form_params).tap do |clean_params|
+          terms.each do |key|
+            if clean_params[key]
+              if multiple?(key)
+                clean_params[key].delete('')
+              elsif clean_params[key] == ''
+                clean_params[key] = nil
+              end
+            end
+          end
         end
-        clean_params
       end
 
       def sanitize_params(form_params)

--- a/spec/forms/hydra_editor_form_spec.rb
+++ b/spec/forms/hydra_editor_form_spec.rb
@@ -29,6 +29,11 @@ describe HydraEditor::Form do
       subject { TestForm.model_attributes(params) }
 
       it { is_expected.to eq('creator' => 'bob', 'title' => []) }
+
+      describe "setting non-multiple attribute to nil when value is empty string" do
+        let(:params) { ActionController::Parameters.new(title: [''], creator: '') }
+        it { is_expected.to eq('creator' => nil, 'title' => []) }
+      end
     end
   end
 


### PR DESCRIPTION
For non-multiple terms, an empty string value is replaced by nil.
Fixes #146.