### PR TITLE
Releases version 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.5.1
-  - 2.4.4
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
 jdk:
   - oraclejdk8
 env:
   matrix:
-    - "RAILS_VERSION=5.2.1"
-    - "RAILS_VERSION=5.1.6"
-    - "RAILS_VERSION=5.0.7"
+    - "RAILS_VERSION=5.2.2"
+    - "RAILS_VERSION=5.1.6.1"
+    - "RAILS_VERSION=5.0.7.1"
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,7 @@ end
 if !ENV['RAILS_VERSION'] || ENV['RAILS_VERSION'] =~ /^5.0/
   gem 'rails-controller-testing'
 end
+
+if ENV['RAILS_VERSION'] =~ /^5\.[0,1]/
+  gem 'active-fedora', '~> 12.0', '< 12.1'
+end

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency "active-fedora", ">= 9.0.0"
   s.add_dependency "almond-rails", '~> 0.1'
   s.add_dependency "cancancan", "~> 1.8"
-  s.add_dependency "rails", ">= 5.0.7", "< 6"
-  s.add_dependency "simple_form", '~> 4.0'
+  s.add_dependency "rails", ">= 5", "< 6"
+  s.add_dependency "simple_form", '>= 3.5.0'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'thor', '~> 0.19'
 

--- a/lib/hydra_editor/version.rb
+++ b/lib/hydra_editor/version.rb
@@ -1,3 +1,3 @@
 module HydraEditor
-  VERSION = '4.0.2'.freeze
+  VERSION = '5.0.0'.freeze
 end

--- a/spec/inputs/multi_value_input_spec.rb
+++ b/spec/inputs/multi_value_input_spec.rb
@@ -17,14 +17,19 @@ describe 'MultiValueInput', type: :input do
 
     context "for values from a property on the object" do
       subject { input_for(foo, :bar, as: :multi_value, required: true) }
+
       it 'renders multi-value' do
-        expect(subject).to have_selector('.form-group.foo_bar.multi_value label.required[for=foo_bar]', text: 'Bar *')
+
+        # For handling older releases of SimpleForm
+        expect(subject).to have_selector('.form-group.foo_bar.multi_value label.required[for=foo_bar]', text: /(\*\s)?Bar(\s\*)?/)
         expect(subject).to have_selector('.form-group.foo_bar.multi_value ul.listing li input.foo_bar', count: 3)
       end
     end
 
     context 'for values from a method on the object' do
       subject { input_for(foo, :double_bar, as: :multi_value) }
+
+      # For handling older releases of SimpleForm
       it 'renders multi-value' do
         expect(subject).to have_selector('.form-group.foo_double_bar.multi_value ul.listing li input.foo_double_bar', count: 3)
       end
@@ -40,7 +45,7 @@ describe 'MultiValueInput', type: :input do
     end
 
     it 'renders multi-value given a nil object' do
-      expect(subject).to have_selector('.form-group.foo_bar.multi_value label.required[for=foo_bar]', text: 'Bar *')
+      expect(subject).to have_selector('.form-group.foo_bar.multi_value label.required[for=foo_bar]', text: /(\*\s)?Bar(\s\*)?/)
       expect(subject).to have_selector('.form-group.foo_bar.multi_value ul.listing li input.foo_bar')
     end
   end

--- a/spec/presenters/hydra_editor_presenter_spec.rb
+++ b/spec/presenters/hydra_editor_presenter_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 describe Hydra::Presenter do
   before do
+    class Contributor < ActiveFedora::Base
+      has_and_belongs_to_many :books, predicate: ::RDF::Vocab::DC.title
+    end
+
+    class Publisher < ActiveFedora::Base
+      has_many :books, predicate: ::RDF::Vocab::DC.title
+    end
+
     class TestModel < ActiveFedora::Base
       property :title, predicate: ::RDF::Vocab::DC.title
       property :creator, predicate: ::RDF::Vocab::DC.creator, multiple: false


### PR DESCRIPTION
Proposes the following improvements for a new major release (given the change in support for Rails versions)
- Updates the Rails dependency to releases 5.2.0 or later
- Explicitly provides the Contributor and Publisher models within the test suite for the Presenters after updating to active-fedora release 12.1.0
- Ensures that Travis CI tests against Rails 5.1 and 5.0 releases
- Ensures that the tests are restructured for simple_form releases 3.5.0 onwards