### PR TITLE
[WIP] Updating the simple_form dependency to use 5.0.x releases and releases version 5.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
         default: 1.17.3
       rails_version:
         type: string
+      solr_config_path:
+        type: string
+        default: '.internal_test_app/solr/conf'
     executor:
       name: 'samvera/ruby_fcrepo_solr'
       ruby_version: << parameters.ruby_version >>
@@ -35,7 +38,7 @@ jobs:
       - samvera/engine_cart_generate:
           cache_key: v1-internal-test-app-{{ checksum "hydra-editor.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
       - samvera/install_solr_core:
-          solr_config_path: .internal_test_app/solr/config
+          solr_config_path: << parameters.solr_config_path >>
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>

--- a/History.md
+++ b/History.md
@@ -1,5 +1,15 @@
 # History of hydra-editor releases
 
+## 5.0.1
+* 2019-09-30: Update the dependency for the `simple_form` Gem to 5.0.x releases
+
+## 5.0.0
+* 2019-03-26: Added CodeClimate [@cjcolvar]
+* 2019-03-26: Updates testing for Rails support to releases 5.2.2, 5.1.6.1, and 5.0.7.1 [@cjcolvar]
+* 2019-03-26: Updates simple_form to releases 4.1.0 (or later) [@cjcolvar]
+* 2019-03-26: Updates engine_cart to release 2.2 [@cjcolvar]
+* 2018-08-14: Updates the repository documentation in compliance with the guidelines of the Core Component Maintenance Working Group [@botimer]
+
 ## 4.0.2
 * 2018-05-10: MultiValue gets values from object methods and attributes [afred]
 

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "almond-rails", '~> 0.1'
   s.add_dependency "cancancan", "~> 1.8"
   s.add_dependency "rails", ">= 5", "< 6"
-  s.add_dependency "simple_form", '~> 4.1.0'
+  s.add_dependency "simple_form", '>= 5.0'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'thor', '~> 0.19'
 

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
   s.add_dependency "active-fedora", ">= 9.0.0"
   s.add_dependency "almond-rails", '~> 0.1'
   s.add_dependency "cancancan", "~> 1.8"
+  s.add_dependency "faraday-encoding", ">= 0.0.5"
   s.add_dependency "rails", ">= 5", "< 6"
-  s.add_dependency "simple_form", '>= 5.0'
+  s.add_dependency "simple_form", '>= 4.1.0', '< 6.0'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'thor', '~> 0.19'
 

--- a/lib/hydra_editor/version.rb
+++ b/lib/hydra_editor/version.rb
@@ -1,3 +1,3 @@
 module HydraEditor
-  VERSION = '5.0.0'.freeze
+  VERSION = '5.0.1'.freeze
 end


### PR DESCRIPTION
This is issued in response to https://github.com/plataformatec/simple_form/security/advisories/GHSA-r74q-gxcg-73hx