### PR TITLE
Adding Ruby 2.7.z and Rails 6.y.z releases to the CircleCI build configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,26 +56,42 @@ workflows:
   ci:
     jobs:
       - bundle_lint_test:
+          name: bundle_ruby2-7_rails6-0
+          ruby_version: 2.7.0
+          rails_version: 6.0.2
+      - bundle_lint_test:
+          name: bundle_ruby2-7_rails5-2
+          ruby_version: 2.6.5
+          rails_version: 5.2.4
+      - bundle_lint_test:
+          name: bundle_ruby2-7_rails5-1
+          ruby_version: 2.6.5
+          rails_version: 5.1.7
+      - bundle_lint_test:
+          name: bundle_ruby2-6_rails6-0
+          ruby_version: 2.6.5
+          rails_version: 6.0.2
+      - bundle_lint_test:
           name: bundle_ruby2-6_rails5-2
-          ruby_version: 2.6.3
-          rails_version: 5.2.3
+          ruby_version: 2.6.5
+          rails_version: 5.2.4
       - bundle_lint_test:
           name: bundle_ruby2-6_rails5-1
-          ruby_version: 2.6.3
+          ruby_version: 2.6.5
           rails_version: 5.1.7
       - bundle_lint_test:
           name: bundle_ruby2-5_rails5-2
-          ruby_version: 2.5.5
-          rails_version: 5.2.3
+          ruby_version: 2.5.7
+          rails_version: 5.2.4
       - bundle_lint_test:
           name: bundle_ruby2-5_rails5-1
-          ruby_version: 2.5.5
+          ruby_version: 2.5.7
           rails_version: 5.1.7
       - bundle_lint_test:
           name: bundle_ruby2-4_rails5-2
-          ruby_version: 2.4.6
-          rails_version: 5.2.3
+          ruby_version: 2.4.9
+          rails_version: 5.2.4
       - bundle_lint_test:
           name: bundle_ruby2-4_rails5-1
-          ruby_version: 2.4.6
+          ruby_version: 2.4.9
           rails_version: 5.1.7


### PR DESCRIPTION
Resolves #183 