### PR TITLE
Remove unnecessary thor dependency

### DIFF
--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form", '>= 4.1.0', '< 6.0'
   s.add_dependency 'sprockets', '~> 3.7'
   s.add_dependency 'sprockets-es6'
-  s.add_dependency 'thor', '~> 0.19'
 
   s.add_development_dependency "bixby", '~> 3.0'
   s.add_development_dependency "capybara", '~> 2.4'


### PR DESCRIPTION
As far as I can tell, `thor` is never used explicitly in `hydra-editor` and thus the dependency on it can be removed.

See https://github.com/samvera/browse-everything/issues/338 for related work in `browse-everything`.