### PR TITLE
Hiding the link that could remove required input

### DIFF
--- a/app/assets/stylesheets/hydra-editor/multi_value_fields.scss
+++ b/app/assets/stylesheets/hydra-editor/multi_value_fields.scss
@@ -60,8 +60,8 @@
     margin-bottom: 0.5rem;
   }
 
-  .listing li:only-of-type {
-    width: 100%;
+  .listing li:first-of-type {
+    width: 83.3333333333%;
 
     input {
       border-radius: 4px;


### PR DESCRIPTION
With the following CSS

```css
.multi_value .listing li:first-of-type .remove { display: none; }
.multi_value .listing li:first-of-type { width: 83.333333%; }
```

I get the ![following UI](https://user-images.githubusercontent.com/2130/106814035-c8a28900-663f-11eb-8d33-fc9b1d641de7.png)

I spent some time working through the javascript, and it's a rather nasty labyrinth.  First, all multi-values are written by JS (see the [field_manager.es6 file in Hydra::Editor](https://github.com/samvera/hydra-editor/blob/b0d0eee963ebff8d5769b7e535542ab48f252c07/app/assets/javascripts/hydra-editor/field_manager.es6#L1)).  My hope was to be able to discard the "X Remove" button from the HTML of the first element.  However, that proved difficult as there's an assumption that that HTML will be around when we click the "Add another Title" link.

It would be possible to "store that" somewhere, but that felt like some complicated changes.  Instead I went down the path of CSS and settled on the above.  It's not quite perfect but it does things a little better.  Yes, you could disable stylesheets and thus see the button again. Yes you could inspect element and do nefarious things.  But at the root, this solution preserves the "required" input field AND helps avoid POSTing the form.

Related to samvera/hyrax#3526