### PR TITLE
use `Kernel#Array` to cast values to an Array

### DIFF
--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -74,11 +74,8 @@ class MultiValueInput < SimpleForm::Inputs::CollectionInput
     end
 
     def collection
-      @collection ||= begin
-                        val = object.send(attribute_name)
-                        col = val.respond_to?(:to_ary) ? val.to_ary : val
-                        col.reject { |value| value.to_s.strip.blank? } + ['']
-                      end
+      @collection ||=
+        Array(object.send(attribute_name)).reject { |v| v.to_s.strip.blank? } + ['']
     end
 
     def multiple?; true; end


### PR DESCRIPTION
squash out error prone local logic for array casting, use `Kernel#Array`
instead.

the older logic would fail to cast in the case that the value was a String,
requiring a tight integration between the forms input objects and the
application's forms/models. since the very next line is going to fail if we fail
to cast to an Array, let's do so aggressively here.

it looks as though this line once used `Array#wrap` for this, but this only
works if the object responds to `#to_ary` (Ruby's implicit cast); otherwise
it results in a value like `[["blah"]]`. `Kernel#Array` is willing to perform an
explicit cast.