### PR TITLE
Ensures that CircleCI executes nightly test suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,3 +80,38 @@ workflows:
           name: bundle_ruby2-5_rails5-2
           ruby_version: 2.5.9
           rails_version: 5.2.3
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - bundle_lint_test:
+          name: bundle_ruby2-7_rails6-0
+          ruby_version: 2.7.4
+          rails_version: 6.0.3.4
+      - bundle_lint_test:
+          name: bundle_ruby2-7_rails5-2
+          ruby_version: 2.7.4
+          rails_version: 5.2.3
+      - bundle_lint_test:
+          name: bundle_ruby2-6_rails6-0
+          ruby_version: 2.6.8
+          rails_version: 6.0.3.4
+      - bundle_lint_test:
+          name: bundle_ruby2-6_rails5-2
+          ruby_version: 2.6.8
+          rails_version: 5.2.3
+      - bundle_lint_test:
+          name: bundle_ruby2-5_rails6-0
+          ruby_version: 2.5.9
+          rails_version: 6.0.3.4
+      - bundle_lint_test:
+          name: bundle_ruby2-5_rails5-2
+          ruby_version: 2.5.9
+          rails_version: 5.2.3
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 1.17.3
+        default: 2.3.10
       rails_version:
         type: string
       solr_config_path:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,19 +58,19 @@ workflows:
     jobs:
       - bundle_lint_test:
           name: bundle_ruby2-7_rails6-0
-          ruby_version: 2.7.4
+          ruby_version: 2.7.5
           rails_version: 6.0.3.4
       - bundle_lint_test:
           name: bundle_ruby2-7_rails5-2
-          ruby_version: 2.7.4
+          ruby_version: 2.7.5
           rails_version: 5.2.3
       - bundle_lint_test:
           name: bundle_ruby2-6_rails6-0
-          ruby_version: 2.6.8
+          ruby_version: 2.6.9
           rails_version: 6.0.3.4
       - bundle_lint_test:
           name: bundle_ruby2-6_rails5-2
-          ruby_version: 2.6.8
+          ruby_version: 2.6.9
           rails_version: 5.2.3
       - bundle_lint_test:
           name: bundle_ruby2-5_rails6-0
@@ -92,19 +92,19 @@ workflows:
     jobs:
       - bundle_lint_test:
           name: bundle_ruby2-7_rails6-0
-          ruby_version: 2.7.4
+          ruby_version: 2.7.5
           rails_version: 6.0.3.4
       - bundle_lint_test:
           name: bundle_ruby2-7_rails5-2
-          ruby_version: 2.7.4
+          ruby_version: 2.7.5
           rails_version: 5.2.3
       - bundle_lint_test:
           name: bundle_ruby2-6_rails6-0
-          ruby_version: 2.6.8
+          ruby_version: 2.6.9
           rails_version: 6.0.3.4
       - bundle_lint_test:
           name: bundle_ruby2-6_rails5-2
-          ruby_version: 2.6.8
+          ruby_version: 2.6.9
           rails_version: 5.2.3
       - bundle_lint_test:
           name: bundle_ruby2-5_rails6-0

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "active-fedora", ">= 9.0.0"
   s.add_dependency "almond-rails", '~> 0.1'
   s.add_dependency "cancancan", "~> 1.8"
+  s.add_dependency "psych", "~> 3.3", "< 4"
   s.add_dependency "rails", ">= 5.2", "< 6.1"
   s.add_dependency "simple_form", '>= 4.1.0', '< 6.0'
   s.add_dependency 'sprockets', '>= 3.7'


### PR DESCRIPTION
Resolves #206 and also provides the following:

- Updates the CircleCI Ruby releases to the following:
  - 2.7.5
  - 2.6.9
- Pins the release of `psych` to the 3.3.z series
- Updates `bundler` to release `2.3.10`