### PR TITLE
Prepare for 6.1 release

### DIFF
--- a/lib/hydra_editor/version.rb
+++ b/lib/hydra_editor/version.rb
@@ -1,3 +1,3 @@
 module HydraEditor
-  VERSION = '6.0.0'.freeze
+  VERSION = '6.1.0'.freeze
 end


### PR DESCRIPTION
Relaxes restrictions on activerecord and rails dependencies for Rails 6.1 support  (#210)