### PR TITLE
Fix failing build

### DIFF
--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "cancancan"
   s.add_dependency "psych", "~> 3.3", "< 4"
   s.add_dependency "rails", ">= 5.2", "< 7.1"
-  s.add_dependency "simple_form", '>= 4.1.0', '< 6.0'
+  s.add_dependency "simple_form", '>= 4.1.0', '< 5.2'
   s.add_dependency 'sprockets', '>= 3.7'
   s.add_dependency 'sprockets-es6'
 

--- a/lib/hydra_editor/engine.rb
+++ b/lib/hydra_editor/engine.rb
@@ -3,6 +3,8 @@ module HydraEditor
     require 'simple_form'
     require 'sprockets/es6'
     require 'almond-rails'
+    require 'hydra/head'
+
     engine_name 'hydra_editor'
     config.eager_load_paths += %W[
        #{config.root}/app/helpers/concerns


### PR DESCRIPTION
Somehow everything passed in #216, but broke in `main` possibly due to new releases of other core components.

- Explicitly require hydra-head for zeitwerk
- Restrict to `simple_form` less than 5.2 (released recently)