### PR TITLE
Removal of "autoload :Permissions"

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -1,6 +1,5 @@
 module HydraEditor
   module Form
-    extend ActiveSupport::Autoload
     extend ActiveSupport::Concern
 
     include Hydra::Presenter

--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -1,7 +1,6 @@
 module HydraEditor
   module Form
     extend ActiveSupport::Autoload
-    # autoload :Permissions
     extend ActiveSupport::Concern
 
     include Hydra::Presenter

--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -1,7 +1,7 @@
 module HydraEditor
   module Form
     extend ActiveSupport::Autoload
-    autoload :Permissions
+    # autoload :Permissions
     extend ActiveSupport::Concern
 
     include Hydra::Presenter


### PR DESCRIPTION
Forked the hydra-editor and tested removing the "autoload :Permissions". Rails should automatically load the files in the subfolder. This line was causing errors on our hyrax 4 / Rails 6 setup.

![Screen Shot 2023-08-01 at 11 03 00 AM](https://github.com/samvera/hydra-editor/assets/16909131/083323b6-3cc1-47a4-a5f7-3759558ef7fe)

My removing the command this error stopped.
