### PR TITLE
Fix failing CI

### DIFF
--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "almond-rails", '~> 0.1'
   s.add_dependency "cancancan"
   s.add_dependency "psych", "~> 3.3", "< 4"
-  s.add_dependency "rails", ">= 5.2", "< 8.0"
+  s.add_dependency "rails", ">= 7.0", "< 8.0"
   s.add_dependency "simple_form", '>= 4.1.0', '< 5.2'
   s.add_dependency 'sprockets', '>= 3.7'
   s.add_dependency 'sprockets-es6'


### PR DESCRIPTION
CI was having bundler issues due to previous activation of incompatible version of `error_highlight`.  This seems to have been coming from allowing a wider scope of Rails versions than was necessary.  We aren't testing older than 7.0 anyway, so narrowing the gemspec fixed the problem.