### PR TITLE
Modernize hydra-editor to assume ActionController::Parameter

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -47,14 +47,14 @@ module HydraEditor
         field_metadata_service.multiple?(model_class, field)
       end
 
-      # Return a hash of all the parameters from the form as a hash.
+      # Return an ActionController::Parameters object with all of the parameters from the form.
       # This is typically used by the controller as the main read interface to the form.
       # This hash can then be used to create or update an object in the data store.
       # example:
       #   ImageForm.model_attributes(params[:image])
-      #   # => { title: 'My new image' }
+      #   # => <ActionController::Parameters { title: 'My new image' } permitted: true>
       def model_attributes(form_params)
-        sanitize_params(form_params).to_h.tap do |clean_params|
+        sanitize_params(form_params).tap do |clean_params|
           terms.each do |key|
             if clean_params[key]
               if multiple?(key)

--- a/spec/forms/hydra_editor_form_permissions_spec.rb
+++ b/spec/forms/hydra_editor_form_permissions_spec.rb
@@ -25,8 +25,8 @@ describe HydraEditor::Form::Permissions do
     subject(:permissions) { TestForm.model_attributes(params) }
     let(:params) { ActionController::Parameters.new(title: [''], creator: 'bob', description: ['huh'], permissions_attributes: { '0' => { id: '123', _destroy: 'true' } }) }
 
-    it { is_expected.to eq('creator' => 'bob', 'title' => [],
-                           'permissions_attributes' => { '0' => { 'id' => '123', '_destroy' => 'true' } }) }
+    it { is_expected.to eq ActionController::Parameters.new('creator' => 'bob', 'title' => [],
+                                                            'permissions_attributes' => { '0' => { 'id' => '123', '_destroy' => 'true' } }).permit! }
   end
 
   describe 'permissions_attributes=' do

--- a/spec/forms/hydra_editor_form_spec.rb
+++ b/spec/forms/hydra_editor_form_spec.rb
@@ -28,11 +28,11 @@ describe HydraEditor::Form do
       subject { TestForm.model_attributes(params) }
       let(:params) { ActionController::Parameters.new(title: [''], creator: 'bob', description: ['huh']) }
 
-      it { is_expected.to eq('creator' => 'bob', 'title' => []) }
+      it { is_expected.to eq ActionController::Parameters.new('creator' => 'bob', 'title' => []).permit! }
 
       describe "setting non-multiple attribute to nil when value is empty string" do
         let(:params) { ActionController::Parameters.new(title: [''], creator: '') }
-        it { is_expected.to eq('creator' => nil, 'title' => []) }
+        it { is_expected.to eq ActionController::Parameters.new('creator' => nil, 'title' => []).permit! }
       end
     end
   end


### PR DESCRIPTION
hydra-editor may not have been modernized when upgrading to rails 5 which made a switch from expecting hashes to ActionController::Parameter objects.  This seems to have slipped by because ActionController::Parameter == Hash as being tested in the spec test was still supported by Rails although deprecated.  In Rails 7.2 this comparison has been dropped which caused the tests to fail and my quick solution at the time was to match the inline comment above the #model_attributes method and return a hash.  This broke tests in Hyrax when upgrading to Rails 7.2.  It seems like changing the tests to expect ActionController::Parameter objects instead of hashes is probably the better solution.

See https://github.com/rails/rails/commit/43e42c1ea879de70d42caa0acbc9b24faf74dc1a