### PR TITLE
Release v7

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,2 +1,2 @@
 unreleased=true
-future-release=6.3.0
+future-release=7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## [6.3.0](https://github.com/samvera/hydra-editor/tree/6.3.0) (2024-10-01)
+## [7.0.0](https://github.com/samvera/hydra-editor/tree/7.0.0) (2025-01-31)
 
-[Full Changelog](https://github.com/samvera/hydra-editor/compare/v6.2.0...6.3.0)
+[Full Changelog](https://github.com/samvera/hydra-editor/compare/v6.3.0...7.0.0)
+
+**Merged pull requests:**
+
+- Modernize hydra-editor to assume ActionController::Parameter [\#225](https://github.com/samvera/hydra-editor/pull/225) ([cjcolvar](https://github.com/cjcolvar))
+- Comment out error\_highlight  in generated test app's Gemfile [\#224](https://github.com/samvera/hydra-editor/pull/224) ([cjcolvar](https://github.com/cjcolvar))
+
+## [v6.3.0](https://github.com/samvera/hydra-editor/tree/v6.3.0) (2024-10-02)
+
+[Full Changelog](https://github.com/samvera/hydra-editor/compare/v6.2.0...v6.3.0)
 
 **Closed issues:**
 
@@ -10,6 +19,7 @@
 
 **Merged pull requests:**
 
+- Prepare for release [\#222](https://github.com/samvera/hydra-editor/pull/222) ([cjcolvar](https://github.com/cjcolvar))
 - Test with latest ruby/rails versions [\#221](https://github.com/samvera/hydra-editor/pull/221) ([cjcolvar](https://github.com/cjcolvar))
 - Removal of "autoload :Permissions" [\#220](https://github.com/samvera/hydra-editor/pull/220) ([trmccormick](https://github.com/trmccormick))
 

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form", '>= 4.1.0', '< 5.2'
   s.add_dependency 'sprockets', '>= 3.7'
   s.add_dependency 'sprockets-es6'
+  s.add_dependency 'concurrent-ruby', '1.3.4' # Pinned until Rails 7 update
 
   s.add_development_dependency "bixby"
   s.add_development_dependency "capybara", '~> 2.4'

--- a/lib/hydra_editor/version.rb
+++ b/lib/hydra_editor/version.rb
@@ -1,3 +1,3 @@
 module HydraEditor
-  VERSION = '6.3.0'.freeze
+  VERSION = '7.0.0'.freeze
 end


### PR DESCRIPTION
The changes in #225 change the return value of `model_attributes` which has downstream implications so I think this should be a major version.  We probably should add some more notes about upgrading in the README or github release notes.