### PR TITLE
Remove rails 8.1 from nightly test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,6 @@ workflows:
     jobs:
       # Ruby 3.3 releases
       - bundle_lint_test:
-          name: bundle_ruby3-3_rails8-1
-          ruby_version: 3.3.5
-          rails_version: 8.1.1
-      - bundle_lint_test:
           name: bundle_ruby3-3_rails8-0
           ruby_version: 3.3.5
           rails_version: 8.0.4
@@ -137,10 +133,6 @@ workflows:
           ruby_version: 3.3.5
           rails_version: 7.0.8.4
       # Ruby 3.2 releases
-      - bundle_lint_test:
-          name: bundle_ruby3-2_rails8-1
-          ruby_version: 3.2.5
-          rails_version: 8.1.1
       - bundle_lint_test:
           name: bundle_ruby3-2_rails8-0
           ruby_version: 3.2.5


### PR DESCRIPTION
hydra-editor doesn't allow rails 8.1 yet so no point in testing these.